### PR TITLE
Fix, use productized images for Upgrade

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -186,6 +186,11 @@ create_templates() {
         -e "s#\(03_jboss_ea:\s*\).*#03_jboss: $maven_jboss_repository#" \
         -i "$topdir/resources/fuse-ignite-oso.yml" "$topdir/resources/fuse-ignite-ocp.yml"
 
+    local fuse_ignite_upgrade=$(read_image_version fuse-ignite-upgrade)
+    echo "==== Patch install script with productized syndesis-upgrade images"
+    sed -e "s#image:\s*syndesis/syndesis-upgrade.*#image: $docker_image_repository/fuse-ignite-upgrade:$fuse_ignite_upgrade#" \
+        -i "$topdir/resources/fuse-ignite-oso.yml" "$topdir/resources/fuse-ignite-ocp.yml"
+
     echo "==== Copy support SA"
     cp ../support/serviceaccount-as-oauthclient-restricted.yml \
        "$topdir/resources/serviceaccount-as-oauthclient-restricted.yml"

--- a/resources/fuse-ignite-ocp.yml
+++ b/resources/fuse-ignite-ocp.yml
@@ -1519,7 +1519,7 @@ objects:
     spec:
       containers:
       - name: upgrade
-        image: syndesis/syndesis-upgrade:${SYNDESIS_VERSION}
+        image: fuse7/fuse-ignite-upgrade:1.0-2
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/resources/fuse-ignite-oso.yml
+++ b/resources/fuse-ignite-oso.yml
@@ -1516,7 +1516,7 @@ objects:
     spec:
       containers:
       - name: upgrade
-        image: syndesis/syndesis-upgrade:${SYNDESIS_VERSION}
+        image: fuse7/fuse-ignite-upgrade:1.0-2
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:


### PR DESCRIPTION
Built with:
```bash
sh release.sh --version-syndesis 1.3.5 --version-fuse-ignite 1.3.5 --version-brew  1.0-1  --version-fuse-ignite-server 1.0-2 --version-fuse-ignite-upgrade 1.0-2  --docker-registry brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888 --docker-image-repository fuse7  --maven-redhat-repository 'http://indy.cloud.pnc.engineering.redhat.com/api/group/builds-untested+shared-imports+public/' --maven-jboss-repository https://repository.jboss.org/nexus/content/groups/ea  --version-fuse-ignite-upgrade 1.0-2
```