### PR TITLE
Syndesis #3515: remove command override from operator deployment

### DIFF
--- a/resources/fuse-online-operator.yml
+++ b/resources/fuse-online-operator.yml
@@ -175,8 +175,6 @@ spec:
       containers:
         - name: syndesis-operator
           image: ' '
-          command:
-          - syndesis-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/templates/fuse-online-operator.yml
+++ b/templates/fuse-online-operator.yml
@@ -175,8 +175,6 @@ spec:
       containers:
         - name: syndesis-operator
           image: ' '
-          command:
-          - syndesis-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
@avano, @heiko-braun I think this should be sufficient for https://github.com/syndesisio/syndesis/issues/3515.