### PR TITLE
Added CPU limits and requests to pods

### DIFF
--- a/resources/fuse-online-template.yml
+++ b/resources/fuse-online-template.yml
@@ -254,8 +254,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
       type: Rolling
     template:
       metadata:
@@ -289,8 +291,10 @@ objects:
           resources:
             limits:
               memory: 255Mi
+              cpu: 450m
             requests:
               memory: 50Mi
+              cpu: 100m
         volumes:
         - configMap:
             name: syndesis-ui-config
@@ -589,8 +593,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
     template:
       metadata:
         labels:
@@ -722,8 +728,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
       type: Recreate
     template:
       metadata:
@@ -773,8 +781,10 @@ objects:
           resources:
             limits:
               memory: ${META_MEMORY_LIMIT}
+              cpu: 750m
             requests:
-              memory: 280Mi
+              memory: 256Mi
+              cpu: 450m
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:
@@ -952,8 +962,10 @@ objects:
           resources:
             limits:
               memory: 200Mi
+              cpu: "450m"
             requests:
               memory: 20Mi
+              cpu: "50m"
         serviceAccountName: syndesis-oauth-client
         volumes:
         - name: syndesis-oauthproxy-tls
@@ -1026,8 +1038,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
       type: Recreate
     template:
       metadata:
@@ -1110,8 +1124,10 @@ objects:
           resources:
             limits:
               memory: ${SERVER_MEMORY_LIMIT}
+              cpu: 750m
             requests:
               memory: 256Mi
+              cpu: 450m
         volumes:
         - name: config-volume
           configMap:
@@ -1300,8 +1316,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
       type: Recreate
     template:
       metadata:
@@ -1329,8 +1347,10 @@ objects:
             resources:
               limits:
                 memory: 256Mi
+                cpu: 450m
               requests:
                 memory: 256Mi
+                cpu: 450m
             ports:
               - containerPort: 8080
                 name: http
@@ -1533,8 +1553,10 @@ objects:
       resources:
         limits:
           memory: "256Mi"
+          cpu: "450m"
         requests:
           memory: "20Mi"
+          cpu: "50m"
     template:
       metadata:
         labels:
@@ -1567,8 +1589,10 @@ objects:
           resources:
             limits:
               memory: ${PROMETHEUS_MEMORY_LIMIT}
+              cpu: "450m"
             requests:
               memory: ${PROMETHEUS_MEMORY_LIMIT}
+              cpu: "50m"
           volumeMounts:
           - name: syndesis-prometheus-data
             mountPath: /prometheus


### PR DESCRIPTION
CPU requests help to stablise the startup of pods, with assurance of minimum CPU allocation. I have added them to the deployment configurations of the pods, and also at container level where needed.