### PR TITLE
[ENTESB-9745] Fuse Online install doesn't work when oc version contains other oc occurences

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -244,7 +244,7 @@ recreate_project() {
 check_oc_version()
 {
     local minimum=${OC_MIN_VERSION}
-    local test=$(oc version | grep oc | tr -d oc\ v | cut -f1 -d "+")
+    local test=$(oc version | grep ^oc | tr -d oc\ v | cut -f1 -d "+")
 
     echo $(compare_oc_version $test $minimum)
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-9745

Already fixed in master branch. See https://github.com/syndesisio/fuse-online-install/commit/af0e6f34b8101a274309e4bbba56aae056d11330#diff-226e72d0faeb1a248b542d6c29c43236