### PR TITLE
fix: widen up the permissions, fixes a copy file permission error on linux

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -215,6 +215,8 @@ create_resources() {
         > $topdir/resources/fuse-online-upgrade.yml
 
     echo "==== Extract Template from Operator image"
+    chmod a+rwx ./resources
+    chmod a+rw ./resources/*
     docker run -v $(pwd)/resources:/resources \
                --entrypoint bash \
                $registry/$repository/fuse-online-operator:$tag_operator \


### PR DESCRIPTION
@vhalbert FYI

Though I wonder if this is needed to run each time the script is run or if it's better to do when first cloning this repo, @heiko-braun @rhuss thoughts?