### PR TITLE
Fix #81: add missing envs and roles to operator deployment

### DIFF
--- a/resources/fuse-online-image-streams.yml
+++ b/resources/fuse-online-image-streams.yml
@@ -5,7 +5,7 @@ items:
   metadata:
     name: fuse-ignite-server
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -23,7 +23,7 @@ items:
   metadata:
     name: fuse-ignite-ui
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -41,7 +41,7 @@ items:
   metadata:
     name: fuse-ignite-meta
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -91,7 +91,7 @@ items:
   metadata:
     name: fuse-ignite-s2i
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -100,7 +100,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.redhat.io/fuse7/fuse-ignite-s2i:1.2-3
+        name: registry.redhat.io/fuse7/fuse-ignite-s2i:1.2-9
       importPolicy:
         scheduled: true
       name: "latest"

--- a/resources/fuse-online-operator.yml
+++ b/resources/fuse-online-operator.yml
@@ -22,9 +22,9 @@ rules:
 - apiGroups:
   - syndesis.io
   resources:
-  - syndesises
-  - syndesises/finalizers
-  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+  - "*"
+  - "*/finalizers"
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
   - ""
   resources:
@@ -44,6 +44,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - roles
   - rolebindings
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
@@ -65,7 +66,6 @@ rules:
   - build.openshift.io
   resources:
   - buildconfigs
-  verbs:
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
   - authorization.openshift.io
@@ -77,6 +77,24 @@ rules:
   resources:
   - routes
   - routes/custom-host
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - "*"
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  - prometheusrules
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanadashboards
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 ---
 kind: RoleBinding
@@ -130,7 +148,7 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   annotations:
-    openshift.io/image.insecureRepository: "true"
+    openshift.io/image.insecureRepository: "false"
   labels:
     app: syndesis
     syndesis.io/app: syndesis
@@ -178,11 +196,20 @@ spec:
         - name: syndesis-operator
           image: ' '
           imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 60000
+              name: metrics
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "syndesis-operator"
   triggers:
   - imageChangeParams:
       automatic: true

--- a/resources/fuse-online-template.yml
+++ b/resources/fuse-online-template.yml
@@ -1665,12 +1665,12 @@ objects:
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-1.2-6
+      name: syndesis-upgrade-1.2-18
     spec:
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade
-        image: ${UPGRADE_REGISTRY}/fuse7/fuse-ignite-upgrade:1.2-6
+        image: ${UPGRADE_REGISTRY}/fuse7/fuse-ignite-upgrade:1.2-18
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/resources/fuse-online-upgrade.yml
+++ b/resources/fuse-online-upgrade.yml
@@ -1,11 +1,11 @@
 - apiVersion: v1
   kind: Pod
   metadata:
-    name: syndesis-upgrade-1.2-6
+    name: syndesis-upgrade-1.2-18
   spec:
     containers:
     - name: upgrade
-      image: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-uprade:1.2-6
+      image: registry.redhat.io/fuse7/fuse-ignite-uprade:1.2-18
       env:
         - name: SYNDESIS_UPGRADE_PROJECT
           valueFrom:

--- a/templates/fuse-online-operator.yml
+++ b/templates/fuse-online-operator.yml
@@ -22,9 +22,9 @@ rules:
 - apiGroups:
   - syndesis.io
   resources:
-  - syndesises
-  - syndesises/finalizers
-  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+  - "*"
+  - "*/finalizers"
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
   - ""
   resources:
@@ -44,6 +44,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - roles
   - rolebindings
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
@@ -65,7 +66,6 @@ rules:
   - build.openshift.io
   resources:
   - buildconfigs
-  verbs:
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
   - authorization.openshift.io
@@ -77,6 +77,24 @@ rules:
   resources:
   - routes
   - routes/custom-host
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - "*"
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  - prometheusrules
+  verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - integreatly.org
+  resources:
+  - grafanadashboards
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 ---
 kind: RoleBinding
@@ -178,11 +196,20 @@ spec:
         - name: syndesis-operator
           image: ' '
           imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 60000
+              name: metrics
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "syndesis-operator"
   triggers:
   - imageChangeParams:
       automatic: true


### PR DESCRIPTION
Fix #81.
This seems to fix the issue.

Resources under `/templates` are the master version, while the ones under `/resources` are generated during release (I did a `--dry-run` release).