### PR TITLE
Fix #86: use productized version of camel k

### DIFF
--- a/fuse_online_config.sh
+++ b/fuse_online_config.sh
@@ -9,13 +9,15 @@ tag_s2i="1.2-9"
 tag_upgrade="1.2-18"
 tag_operator="1.2-13"
 tag_postgres_exporter="1.3"
+tag_camel_k="1.3"
 
 # Docker repository for productised images
 repository="fuse7"
 
 # Test:
 #registry="brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888"
+#maven_repository="https://origin-repository.jboss.org/nexus/content/groups/ea@id=redhat.ea"
 
 # Official:
-
 registry="registry.redhat.io"
+maven_repository="https://maven.repository.redhat.com/ga@id=redhat.ga"

--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -546,6 +546,11 @@ deploy_camel_k_operator() {
   local kamel=$(get_camel_k_bin "$version")
   $kamel install --skip-cluster-setup --repository $MAVEN_REPOSITORY --context jvm $extra_opts
 
+  if [ -z "$version" ]; then
+    # Patching Camel K image
+    oc patch deployment camel-k-operator --type='json' -p="[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\":\"$REGISTRY/$REPOSITORY/fuse-camel-k:$CAMEL_K_TAG\"}]"
+  fi
+
   local result=$(oc secrets link camel-k-operator syndesis-pull-secret --for=pull >$ERROR_FILE 2>&1)
   check_error $result
 }

--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -525,12 +525,15 @@ get_route() {
 
 # ==================================================================
 
-# Default Camel-K version
-CAMEL_K_DEFAULT_VERSION="0.2.0"
+# Getting options from config file
+eval $(source $(dirname ARGS[0])/fuse_online_config.sh; echo MAVEN_REPOSITORY=$maven_repository)
+eval $(source $(dirname ARGS[0])/fuse_online_config.sh; echo CAMEL_K_TAG=$tag_camel_k)
+eval $(source $(dirname ARGS[0])/fuse_online_config.sh; echo REPOSITORY=$repository)
+eval $(source $(dirname ARGS[0])/fuse_online_config.sh; echo REGISTRY=$registry)
 
 # Deploy Camel-K operator
 deploy_camel_k_operator() {
-  local version=${1:-$CAMEL_K_DEFAULT_VERSION}
+  local version=${1:-}
   local project=${2:-}
   local opts=${3:-}
   local extra_opts=""
@@ -541,7 +544,7 @@ deploy_camel_k_operator() {
     extra_opts="$extra_opts $opts"
   fi
   local kamel=$(get_camel_k_bin "$version")
-  $kamel install --skip-cluster-setup --context jvm $extra_opts
+  $kamel install --skip-cluster-setup --repository $MAVEN_REPOSITORY --context jvm $extra_opts
 
   local result=$(oc secrets link camel-k-operator syndesis-pull-secret --for=pull >$ERROR_FILE 2>&1)
   check_error $result
@@ -549,7 +552,7 @@ deploy_camel_k_operator() {
 
 # Install Camel-K CRD
 install_camel_k_crds() {
-  local version=${1:-$CAMEL_K_DEFAULT_VERSION}
+  local version=${1:-}
   local kamel=$(get_camel_k_bin "$version")
   $kamel install --cluster-setup
 }
@@ -578,11 +581,19 @@ isWindows() {
     fi
 }
 
-# Download `kamel` cli
-# TODO: Adapt this for the productised version of Camel-K
-# Currently it just download from GitHub
 get_camel_k_bin() {
-  local version=${1:-$CAMEL_K_DEFAULT_VERSION}
+    local version=${1:-}
+    if [ -n "$version" ]; then
+        get_upstream_camel_k_bin "$version"
+    else
+        get_product_camel_k_bin
+    fi
+}
+
+# Download upstream `kamel` cli
+# Currently it just download from GitHub
+get_upstream_camel_k_bin() {
+  local version=${1}
   local bin_dir=${2:-/tmp}
 
   local kamel_command="$bin_dir/kamel-${version}"
@@ -608,6 +619,40 @@ get_camel_k_bin() {
   tar xf $archive
   mv ./kamel $kamel_command
   popd >/dev/null
+  [ -n "$tmp_dir" ] && [ -d "$tmp_dir" ] && rm -rf $tmp_dir
+  echo $kamel_command
+}
+
+# Get productized `kamel` cli
+get_product_camel_k_bin() {
+  local bin_dir=${2:-/tmp}
+  local tmp_dir=${bin_dir}/fuse-online-tmp-camel-k-client
+  mkdir -p $tmp_dir
+  chmod a+rw $tmp_dir
+
+  local image=$REGISTRY/$REPOSITORY/fuse-camel-k:$CAMEL_K_TAG
+  local image_sha=$(docker inspect $image --format='{{index .RepoDigests 0}}' | sed 's/.*\://')
+
+  local kamel_command="$bin_dir/kamel-prod-$image_sha"
+  if [ -e $kamel_command ]; then
+    echo $kamel_command
+    return
+  fi
+
+  # Check for proper operating system
+  local os="linux"
+  if $(isMacOs); then
+    os="mac"
+  elif $(isWindows); then
+    os="windows"
+  fi
+
+  docker run -v $tmp_dir/:/client \
+                 --entrypoint bash \
+                 $REGISTRY/$REPOSITORY/fuse-camel-k:$CAMEL_K_TAG\
+                 -c "tar xf /opt/clients/camel-k-client-$os.tar.gz; cp kamel /client/"
+
+  mv -f $tmp_dir/kamel $kamel_command
   [ -n "$tmp_dir" ] && [ -d "$tmp_dir" ] && rm -rf $tmp_dir
   echo $kamel_command
 }


### PR DESCRIPTION
Fix #86

Changed the script to use the productized version (the upstream can be still installed if version is provided explicitly).

The problem is that the `kamel install` command (using the productized `kamel` CLI) generates a deployment with the following image:

```
image: 'docker.io/apache/camel-k:0.3.3-SNAPSHOT'
```

`kamel version` instead returns `1.0.0.fuse-730029`.

So, it seems that IMAGE_NAME has not been overridden when calling `make codegen set-version`.

First issue I see is that `kamel version' is expected to match the Docker image tag, and `1.0.0.fuse-730029` is not the right tag (which is `1.3-1`).

Second issue is that the set-version.sh script in camel k does not replace the registry/repository (issue https://github.com/apache/camel-k/issues/602).
