### PR TITLE
Fix #121: using registry.redhat.io for all images

### DIFF
--- a/fuse_online_config.sh
+++ b/fuse_online_config.sh
@@ -19,10 +19,5 @@ tag_java_base_image="1.3-10"
 # Docker repository for productised images
 repository="fuse7"
 
-# Test:
-registry="registry.access.redhat.com"
+registry="registry.redhat.io"
 maven_repository="https://maven.repository.redhat.com/ga@id=redhat.ga"
-
-# Official:
-# registry="registry.access.redhat.com"
-# maven_repository="https://maven.repository.redhat.com/ga@id=redhat.ga"

--- a/import_images.pl
+++ b/import_images.pl
@@ -66,11 +66,11 @@ my $RELEASE_MAP =
 my $EXTRA_IMAGES =
   [
     {
-      source => "registry.access.redhat.com/openshift3/oauth-proxy:v3.10.45",
+      source => "registry.redhat.io/openshift3/oauth-proxy:v3.10.45",
       target =>  "oauth-proxy:v1.1.0"
     },
     {
-      source => "registry.access.redhat.com/openshift3/prometheus:v3.9.25",
+      source => "registry.redhat.io/openshift3/prometheus:v3.9.25",
       target => "prometheus:v2.1.0"
     },
     {

--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -7,7 +7,7 @@
 
 # ================
 # Tag updated by release script
-TAG=1.6.5
+TAG=1.6.17
 
 # Minimal version for OC
 OC_MIN_VERSION=3.9.0

--- a/resources/fuse-online-image-streams.yml
+++ b/resources/fuse-online-image-streams.yml
@@ -5,7 +5,7 @@ items:
   metadata:
     name: fuse-ignite-server
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -14,7 +14,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-server:1.3-4
+        name: registry.redhat.io/fuse7/fuse-ignite-server:1.3-16
       importPolicy:
         scheduled: true
       name: "1.6"
@@ -23,7 +23,7 @@ items:
   metadata:
     name: fuse-ignite-ui
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -32,7 +32,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-ui:1.3-4
+        name: registry.redhat.io/fuse7/fuse-ignite-ui:1.3-10
       importPolicy:
         scheduled: true
       name: "1.6"
@@ -41,7 +41,7 @@ items:
   metadata:
     name: fuse-ignite-meta
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -50,7 +50,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-meta:1.3-4
+        name: registry.redhat.io/fuse7/fuse-ignite-meta:1.3-16
       importPolicy:
         scheduled: true
       name: "1.6"
@@ -66,7 +66,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/openshift3/oauth-proxy:v3.10.45
+        name: registry.redhat.io/openshift3/oauth-proxy:v3.10.45
       importPolicy:
         scheduled: true
       name: "v1.1.0"
@@ -82,7 +82,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/openshift3/prometheus:v3.9.25
+        name: registry.redhat.io/openshift3/prometheus:v3.9.25
       importPolicy:
         scheduled: true
       name: "v2.1.0"
@@ -91,7 +91,7 @@ items:
   metadata:
     name: fuse-ignite-s2i
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       syndesis.io/app: syndesis
       syndesis.io/type: infrastructure
@@ -100,7 +100,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-s2i:1.3-4
+        name: registry.redhat.io/fuse7/fuse-ignite-s2i:1.3-16
       importPolicy:
         scheduled: true
       name: "1.6"
@@ -109,7 +109,7 @@ items:
   metadata:
     name: postgres_exporter
     annotations:
-      openshift.io/image.insecureRepository: "true"
+      openshift.io/image.insecureRepository: "false"
     labels:
       app: syndesis
       syndesis.io/app: syndesis
@@ -119,7 +119,7 @@ items:
     tags:
       - from:
           kind: DockerImage
-          name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-postgres-exporter:1.3
+          name: registry.redhat.io/fuse7-tech-preview/fuse-postgres-exporter:1.3-4
         importPolicy:
           scheduled: true
         name: "v0.4.7"

--- a/resources/fuse-online-operator.yml
+++ b/resources/fuse-online-operator.yml
@@ -148,7 +148,7 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   annotations:
-    openshift.io/image.insecureRepository: "true"
+    openshift.io/image.insecureRepository: "false"
   labels:
     app: syndesis
     syndesis.io/app: syndesis
@@ -162,7 +162,7 @@ spec:
   - from:
       kind: DockerImage
       # Keep tag 'latest' here, its used as an anchor in the release script
-      name: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-online-operator:1.3-5
+      name: registry.redhat.io/fuse7/fuse-online-operator:1.3-9
     importPolicy:
       scheduled: true
     name: "1.6"

--- a/resources/fuse-online-template.yml
+++ b/resources/fuse-online-template.yml
@@ -1871,38 +1871,6 @@ objects:
         maxIntegrationsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         maxDeploymentsPerUser: ${MAX_INTEGRATIONS_PER_USER}
         integrationStateCheckInterval: ${INTEGRATION_STATE_CHECK_INTERVAL}
-# Access to Camel-K resources
-- kind: Role
-  apiVersion: rbac.authorization.k8s.io/v1beta1
-  metadata:
-    name: camel-k
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-server
-  rules:
-  - apiGroups:
-    - camel.apache.org
-    resources:
-    - "*"
-    verbs: [ get, list, create, update, delete, deletecollection, watch]
-- kind: RoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1beta1
-  metadata:
-    name: camel-k
-    labels:
-      app: syndesis
-      syndesis.io/app: syndesis
-      syndesis.io/type: infrastructure
-      syndesis.io/component: syndesis-server
-  subjects:
-  - kind: ServiceAccount
-    name: syndesis-server
-  roleRef:
-    kind: Role
-    name: camel-k
-    apiGroup: rbac.authorization.k8s.io
 - apiVersion: v1
   kind: Service
   metadata:
@@ -2039,7 +2007,6 @@ objects:
             ports:
               - containerPort: 8080
                 name: http
-            resources: {}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
         dnsPolicy: ClusterFirst
@@ -2356,12 +2323,12 @@ objects:
   - apiVersion: v1
     kind: Pod
     metadata:
-      name: syndesis-upgrade-1.3-5
+      name: syndesis-upgrade-1.3-9
     spec:
       serviceAccountName: syndesis-operator
       containers:
       - name: upgrade
-        image: ${UPGRADE_REGISTRY}/fuse7/fuse-ignite-upgrade:1.3-5
+        image: ${UPGRADE_REGISTRY}/fuse7/fuse-ignite-upgrade:1.3-9
         env:
           - name: SYNDESIS_UPGRADE_PROJECT
             valueFrom:

--- a/resources/fuse-online-upgrade.yml
+++ b/resources/fuse-online-upgrade.yml
@@ -1,11 +1,11 @@
 - apiVersion: v1
   kind: Pod
   metadata:
-    name: syndesis-upgrade-1.3-5
+    name: syndesis-upgrade-1.3-9
   spec:
     containers:
     - name: upgrade
-      image: brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/fuse7/fuse-ignite-uprade:1.3-5
+      image: registry.redhat.io/fuse7/fuse-ignite-uprade:1.3-9
       env:
         - name: SYNDESIS_UPGRADE_PROJECT
           valueFrom:

--- a/templates/fuse-online-image-streams.yml
+++ b/templates/fuse-online-image-streams.yml
@@ -66,7 +66,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/openshift3/oauth-proxy:v3.10.45
+        name: registry.redhat.io/openshift3/oauth-proxy:v3.10.45
       importPolicy:
         scheduled: true
       name: "v1.1.0"
@@ -82,7 +82,7 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.access.redhat.com/openshift3/prometheus:v3.9.25
+        name: registry.redhat.io/openshift3/prometheus:v3.9.25
       importPolicy:
         scheduled: true
       name: "v2.1.0"

--- a/update_ocp.sh
+++ b/update_ocp.sh
@@ -5,7 +5,7 @@
 
 # ================
 # Target version to update to
-TAG=1.6.5
+TAG=1.6.17
 
 # Minimal version for OC
 OC_MIN_VERSION=3.9.0


### PR DESCRIPTION
This basically uses the new registry for all images. I've tested it and I can install and run syndesis directly without hacking with images.