### PR TITLE
[PGExporter] Create all imagestreams after secret

### DIFF
--- a/update_ocp.sh
+++ b/update_ocp.sh
@@ -455,9 +455,9 @@ if [[ $git_fuse_online_install =~ ^1\.6\.[0-9]+$ ]]; then
   delete_openshift_resource "resources/fuse-online-operator.yml"
   create_openshift_resource "resources/fuse-online-operator.yml"
 
-  recreate_openshift_resource "resources/fuse-online-image-streams.yml"
 
   create_secret_if_not_present
+  recreate_openshift_resource "resources/fuse-online-image-streams.yml"
   for sa in syndesis-operator camel-k-operator
   do
     if $(check_resource sa $sa) ; then


### PR DESCRIPTION
@heiko-braun before doing the upgrade from 7.2 to 7.3, it is necessary to create the new image streams (for 7.3 the only new image stream is postgres_exporter) after we create the secret, otherwise the initial pull by openshift ends with the image not pulled to the image stream because of:

```
Name:			postgres_exporter
Namespace:		syndesis
Created:		About a minute ago
Labels:			app=syndesis
			syndesis.io/app=syndesis
			syndesis.io/component=syndesis-db-metrics
			syndesis.io/type=infrastructure
Annotations:		openshift.io/image.dockerRepositoryCheck=2019-05-03T11:09:06Z
			openshift.io/image.insecureRepository=false
Docker Pull Spec:	172.30.1.1:5000/syndesis/postgres_exporter
Image Lookup:		local=false
Unique Images:		0
Tags:			1

v0.4.7
  updates automatically from registry registry.redhat.io/fuse7-tech-preview/fuse-postgres-exporter:1.3-4

  ! error: Import failed (InternalError): Internal error occurred: Get https://registry.redhat.io/v2/fuse7-tech-preview/fuse-postgres-exporter/manifests/1.3-4: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/articles/3399531
      About a minute ago

```