### PR TITLE
Replace ClusterRole with Role

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -267,6 +267,9 @@ check_oc_version()
 {
     local minimum=${OC_MIN_VERSION}
     local test=$(oc version | grep ^oc | tr -d oc\ v | cut -f1 -d "+")
+    if [ "$test" = "" ]; then
+        local test=$(oc version | grep 'Client Version' | sed "s/^.*GitVersion:\"v\(.*\)\", GitCommit.*$/\1/")
+    fi
 
     echo $(compare_oc_version $test $minimum)
 }

--- a/install_test.sh
+++ b/install_test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Fast recreate syndesis environment for testing
+#
+
+PROJECT=${1:-syndesis}
+
+function wait_for() {
+	local cmd=$1
+	local progress=''
+
+        while true 
+        do
+		eval $cmd
+		local rc=$?
+
+        	progress="${progress}."
+        	echo -ne "$progress\r"
+        	sleep 1
+		
+		if [[ "$rc" == "1" ]]
+		then
+			break
+		fi
+        done
+	echo -ne '\n'
+}
+
+function create_project() {
+	local project=$1
+
+	echo "Creating namespace $project ..."
+        oc new-project $project >/dev/null 2>&1
+
+	echo "Waiting for namespace $project to be ready"
+	wait_for "oc get project $project | grep NotFound >/dev/null 2>&1" 
+
+	echo "Namespace $project is ready"
+}
+
+function delete_project() {
+	local project=$1
+
+	echo "Deleting namespace $project"
+        oc delete project $project >/dev/null 2>&1
+
+	echo "Waiting for namespace $project to be deleted"
+	wait_for "oc get project $project >/dev/null 2>&1" 
+
+	echo "Namespace $project is deleted"
+}
+
+function recreate_project() {
+	local project=$1
+
+	delete_project $project
+	create_project $project
+}
+
+[[ -z $DEVELOPERS_REDHAT_COM_USER ]] && echo "DEVELOPERS_REDHAT_COM_USER not set" && exit 1
+[[ -z $DEVELOPERS_REDHAT_COM_PASS ]] && echo "DEVELOPERS_REDHAT_COM_PASS not set" && exit 1
+
+recreate_project $PROJECT
+oc project $PROJECT
+
+./install_ocp.sh --setup;
+
+oc create secret docker-registry syndesis-pull-secret \
+	--docker-server=registry.redhat.io \
+	--docker-username=$DEVELOPERS_REDHAT_COM_USER \
+	--docker-password=$DEVELOPERS_REDHAT_COM_PASS
+
+./install_ocp.sh
+
+ exit 0

--- a/resources/fuse-online-operator.yml
+++ b/resources/fuse-online-operator.yml
@@ -39,6 +39,68 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs: [ get ]
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - replicationcontrollers/status
+  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds
+  - buildconfigs
+  - builds/details
+  - buildconfigs/webhooks
+  - buildconfigs/instantiatebinary
+  - builds/log
+  verbs: [ get, list, create, update, delete, deletecollection, watch ]
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigrollbacks
+  - deploymentconfigs/instantiate
+  - deploymentconfigs/rollback
+  verbs: [ create ]
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/log
+  - deploymentconfigs/status
+  verbs: [ get, list, watch ]
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams
+  - imagestreamimages
+  - imagestreammappings
+  - imagestreams/secrets
+  - imagestreamtags
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/status
+  - imagestreamimports
+  verbs: [ get, list, watch ]
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs: [ get, list ]
 - apiGroups:
@@ -48,25 +110,14 @@ rules:
   - rolebindings
   verbs: [ get, list, create, update, delete, deletecollection, watch]
 - apiGroups:
+  - ""
   - template.openshift.io
   resources:
   - processedtemplates
-  verbs: [ get, list, create, update, delete, deletecollection, watch]
-- apiGroups:
-  - image.openshift.io
-  resources:
-  - imagestreams
-  verbs: [ get, list, create, update, delete, deletecollection, watch]
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs: [ get, list, create, update, delete, deletecollection, watch]
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - buildconfigs
-  verbs: [ get, list, create, update, delete, deletecollection, watch]
+  - templateconfigs
+  - templateinstances
+  - templates
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
 - apiGroups:
   - authorization.openshift.io
   resources:
@@ -96,6 +147,16 @@ rules:
   resources:
   - grafanadashboards
   verbs: [ get, list, create, update, delete, deletecollection, watch]
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs: [ get, list, watch]
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - channels
+  verbs: [ get, list, watch]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -114,36 +175,6 @@ roleRef:
   name: syndesis-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
-metadata:
-  name: syndesis-operator:view
-  labels:
-    app: syndesis
-    syndesis.io/app: syndesis
-    syndesis.io/type: operator
-    syndesis.io/component: syndesis-operator
-subjects:
-- kind: ServiceAccount
-  name: syndesis-operator
-roleRef:
-  name: view
----
-kind: RoleBinding
-apiVersion: authorization.openshift.io/v1
-metadata:
-  name: syndesis-operator:edit
-  labels:
-    app: syndesis
-    syndesis.io/app: syndesis
-    syndesis.io/type: operator
-    syndesis.io/component: syndesis-operator
-subjects:
-- kind: ServiceAccount
-  name: syndesis-operator
-roleRef:
-  name: edit
----
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
@@ -161,8 +192,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      # Keep tag 'latest' here, its used as an anchor in the release script
-      name: registry.redhat.io/fuse7/fuse-online-operator:1.2-13
+      name: lgarciaac/syndesis-operator:latest
     importPolicy:
       scheduled: true
     name: "latest"


### PR DESCRIPTION
This PR depends on https://github.com/syndesisio/syndesis/pull/5706 being merged and the new operator image being updated in this repository. 

- Remove the `RoleBindings` for `ClusterRoles` edit and view. https://github.com/syndesisio/syndesis/pull/5706 makes sure that only the minimum required permissions are used by the operator.
- Add all the minimum permissions  required for the operator to work (it was previously part of *edit* and *view*)
- Fix `install_ocp.sh` to catch new `oc version` output format
- Add `install_test.sh` for easily recreate everything from scratch