### PR TITLE
Fix #161: add extra permission to install user

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -198,6 +198,11 @@ rules:
   - serviceaccounts
   verbs: [ get, list, create, update, delete, deletecollection, watch ]
 - apiGroups:
+  - extensions
+  resources:
+  - deployments/rollback
+  verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+- apiGroups:
   - ""
   resources:
   - pods/log


### PR DESCRIPTION
Fix #161

This should add the missing permission to the install user, even if not present by default.