### PR TITLE
[ENTESB-11268] Fuse Online: Installation fails for user-name having comma in between.

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -195,7 +195,7 @@ EOT
         fi
     fi
 
-    oc $oc_command syndesis-extra-permissions $user
+    oc $oc_command syndesis-extra-permissions "$user"
     if [ $? -ne 0 ]; then
         echo "ERROR: Can not add role 'syndesis-extra-permssionns' to user $user. Does the user exist ?"
         exit 1


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-11268