### PR TITLE
ENTESB-11837: extract binaries from productization and publish them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 .project
 .metadata
+
+.envrc

--- a/common_config.sh
+++ b/common_config.sh
@@ -15,16 +15,22 @@ CURRENT_OS=$(get_current_os)
 BINARY_FILE_EXTENSION=$(get_executable_file_extension)
 OC_MIN_VERSION=3.9.0
 
+COMMON_RELEASE_GIT_ORG=jboss-fuse
+COMMON_RELEASE_GIT_REPO=fuse-clients
+BIN_TAG_PREFIX=
+
 # Camel K settings
-CAMEL_K_VERSION=0.3.4
+CAMEL_K_VERSION=$TAG_FUSE_ONLINE_INSTALL
 CAMEL_K_BINARY=kamel
-CAMEL_K_GIT_ORG=jboss-fuse
-CAMEL_K_GIT_REPO=camel-k
-CAMEL_K_DOWNLOAD_URL=https://github.com/${CAMEL_K_GIT_ORG}/${CAMEL_K_GIT_REPO}/releases/download/${CAMEL_K_VERSION}/camel-k-client-${CAMEL_K_VERSION}-${CURRENT_OS}-64bit.tar.gz
+CAMEL_K_GIT_ORG=$COMMON_RELEASE_GIT_ORG
+CAMEL_K_GIT_REPO=$COMMON_RELEASE_GIT_REPO
+CAMEL_K_DOWNLOAD_URL=https://github.com/${CAMEL_K_GIT_ORG}/${CAMEL_K_GIT_REPO}/releases/download/${BIN_TAG_PREFIX}${CAMEL_K_VERSION}/camel-k-client-${CAMEL_K_VERSION}-${CURRENT_OS}-64bit.tar.gz
+CAMEL_K_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/fuse7-tech-preview-fuse-camel-k:1.5-12
 
 # Syndesis settings
-SYNDESIS_VERSION=1.8.1-20190920
-SYNDESIS_BINARY=syndesis
-SYNDESIS_GIT_ORG=nicolaferraro
-SYNDESIS_GIT_REPO=syndesis
-SYNDESIS_DOWNLOAD_URL=https://github.com/${SYNDESIS_GIT_ORG}/${SYNDESIS_GIT_REPO}/releases/download/${SYNDESIS_VERSION}/syndesis-${SYNDESIS_VERSION}-${CURRENT_OS}-64bit.tgz
+SYNDESIS_VERSION=$TAG_FUSE_ONLINE_INSTALL
+SYNDESIS_BINARY=syndesis-operator
+SYNDESIS_GIT_ORG=$COMMON_RELEASE_GIT_ORG
+SYNDESIS_GIT_REPO=$COMMON_RELEASE_GIT_REPO
+SYNDESIS_DOWNLOAD_URL=https://github.com/${SYNDESIS_GIT_ORG}/${SYNDESIS_GIT_REPO}/releases/download/${BIN_TAG_PREFIX}${SYNDESIS_VERSION}/syndesis-${SYNDESIS_VERSION}-${CURRENT_OS}-64bit.tar.gz
+SYNDESIS_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.5-7

--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -83,12 +83,12 @@ readopt() {
 BASEDIR=$(basedir)
 
 # Get configuration and other scripts
-pushd . && cd $BASEDIR
+pushd > /dev/null . && cd $BASEDIR
 source $BASEDIR/base_functions.sh
 source $BASEDIR/common_config.sh
 source $BASEDIR/libs/download_functions.sh
 source $BASEDIR/libs/openshift_functions.sh
-popd
+popd > /dev/null
 
 SYNDESIS_CLI=$(get_syndesis_bin)
 check_error $SYNDESIS_CLI

--- a/libs/docker_functions.sh
+++ b/libs/docker_functions.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Functions related to extracting artifacts from docker images
+
+source $BASEDIR/common_config.sh
+
+# Download CLI
+extract_from_docker() {
+  local image=${1}
+  local files=${2}
+  local destination=${3}
+
+  set +e
+  docker pull $image >$ERROR_FILE 2>&1
+  local err=$?
+  set -e
+  if [ $err -ne 0 ]; then
+    echo "ERROR: Cannot pull image $image."
+    return
+  fi
+
+  set +e
+  docker run -u root -v $destination/:/client:z \
+               --entrypoint bash \
+               $image\
+               -c "cp --dereference -r $files /client/; chmod -R a+rw /client/" >$ERROR_FILE 2>&1
+  local err=$?
+  set -e
+  if [ $err -ne 0 ]; then
+    echo "ERROR: Cannot copy client binaries from image $image."
+    return
+  fi
+}


### PR DESCRIPTION
This extracts binaries from productized artifacts, uniform them to a common pattern and releases them into the (newly created) project: https://github.com/jboss-fuse/fuse-clients

(in case you need to redeploy artifacts, you need to change the tag or delete the release manually).

Artifacts are extracted from the docker images. Images and tags can be specified in the common_config file.

After a complete release is done, it should be possible for a user to install fuse using the usual commands (although I've not tested what happens after the syndesis and camel-k operators installation).