### PR TITLE
chore(release): Fix config for next releases

### DIFF
--- a/common_config.sh
+++ b/common_config.sh
@@ -5,7 +5,7 @@
 source $BASEDIR/base_functions.sh
 
 # Tag for release. Update this before running release.sh
-TAG_FUSE_ONLINE_INSTALL=1.8.2
+TAG_FUSE_ONLINE_INSTALL=1.8.3
 
 # Fuse minor version (update it manually)
 TAG=1.8

--- a/common_config.sh
+++ b/common_config.sh
@@ -5,7 +5,7 @@
 source $BASEDIR/base_functions.sh
 
 # Tag for release. Update this before running release.sh
-TAG_FUSE_ONLINE_INSTALL=1.8.3
+TAG_FUSE_ONLINE_INSTALL=1.8.4
 
 # Fuse minor version (update it manually)
 TAG=1.8

--- a/release.sh
+++ b/release.sh
@@ -377,6 +377,7 @@ release() {
 
     echo "==== Committing"
     cd $topdir
+    git add common_config.sh
     git_commit "common_config.sh" "Update release config for $TAG_FUSE_ONLINE_INSTALL" "$TAG_FUSE_ONLINE_INSTALL"
 
     # No tagging when just running on master


### PR DESCRIPTION
So the release process is as simple as (in `common_config.sh`)
- Increase TAG_FUSE_ONLINE_INSTALL
- Change CAMEL_K_IMAGE with the new image coming from prod
- Change SYNDESIS_IMAGE with the new image coming from prod

```
bash release.sh --git-push --move-tag --git-remote upstream
```

Ensure you have set the `GITHUB_USERNAME` and `GITHUB_ACCESS_TOKEN` (with 'repo', 'admin:org_hook' and 'admin:repo_hook' scopes) environment variables.
I use [direnv](https://direnv.net/) to have them always available in the project.
You need also to be member of the [jboss-fuse](https://github.com/jboss-fuse) org.

cc: @phantomjinx 