### PR TITLE
ENTESB-12130: Removes finalizers permission from syndesis-editor role

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -344,6 +344,14 @@ release_template() {
       echo "ERROR: Cannot generate template from syndesis-operator"
       return
     fi
+
+    #
+    # Need to remove the deploymentconfigs/finalizers permission from template since the user installing the template
+    # on some systems does not normally have this permission.
+    # This will cause issues, as documented in ENTESB-11639, but that's a short-term balance to be struck.
+    #
+    sed -i '/deploymentconfigs\/finalizers/d' $FUSE_TEMPLATE
+
     mkdir -p $release_dir
     mv $FUSE_TEMPLATE $release_dir/
     popd > /dev/null

--- a/templates/fuse-online-template.yml
+++ b/templates/fuse-online-template.yml
@@ -1388,7 +1388,6 @@ objects:
     resources:
     - deploymentconfigs
     - deploymentconfigs/scale
-    - deploymentconfigs/finalizers
     verbs:
     - get
     - list


### PR DESCRIPTION
* This permission can only be assigned by
 - system:cluster-admins
 - system:masters

* In cases where templates are used rather than the operator, the user
  installing is not normally allowed these roles so on balance its deemed
  best to remove these permission from the syndesis-editor role.