### PR TITLE
Addresses logging failure and ENTESB-12633

### DIFF
--- a/default-cr.yml
+++ b/default-cr.yml
@@ -1,0 +1,15 @@
+apiVersion: syndesis.io/v1beta1
+kind: Syndesis
+metadata:
+  name: app
+spec:
+  integration:
+    # No limitations by default on OCP
+    limit: 0
+  addons:
+    jaeger:
+      enabled: true
+    camel-k:
+      enabled: false
+    komodo:
+      enabled: false

--- a/libs/openshift_functions.sh
+++ b/libs/openshift_functions.sh
@@ -258,8 +258,10 @@ create_secret_if_not_present() {
 
     echo "enter email address for registry.redhat.io and press [ENTER]: "
     read email
+    set +e
     local result=$(oc create secret docker-registry syndesis-pull-secret --docker-server=registry.redhat.io --docker-username=$username --docker-password=$password --docker-email=$email)
     check_error $result
+    set -e
   fi
 }
 


### PR DESCRIPTION
Despite ENTESB-12969, this creates a default syndesis CR in code ...
* Retains --datavirt and --camel-k for enabling those addons (and since these are conditional easier to create the file contents in code rather than modifying a static file);
* Retains the --custom-resource switch to allow for a user-defined custom-resource turning on any other addons, changing any other properties, eg. routeHostname.