### PR TITLE
[fix] fixed indentation of default-cr.yml

### DIFF
--- a/default-cr.yml
+++ b/default-cr.yml
@@ -87,7 +87,7 @@ spec:
     ops:
       enabled: false
     # Exposes public REST API endpoints for CI/CD pipelines.
-   publicApi:
+    publicApi:
        enabled: false
        # Uncomment & modify to specify the public address for invoking REST API endpoints.
        routeHostname: public-syndesis.a.b.c.d.e


### PR DESCRIPTION
publicApi key had wrong indentation which failed the whole installation