### PR TITLE
Add oc checks and document the oc usage from minishift

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -123,6 +123,7 @@ with options:
 -v --verbose                  Verbose logging
 
 You have to run "--setup --grant <user>" as a cluster-admin before you can install Fuse Online as a user.
+If there is no oc command on the PATH and there is minishift, it uses the oc command from the minishift installation.
 EOT
 }
 

--- a/libs/openshift_functions.sh
+++ b/libs/openshift_functions.sh
@@ -147,11 +147,21 @@ setup_oc() {
     # Check for minishift
     which minishift &>/dev/null
     if [ $? -eq 0 ]; then
-      set -e
-      eval $(minishift oc-env)
-      err=$(check_oc_version)
-      check_error $err
-      return
+      mini_running=$(minishift oc-env|grep -c PATH)
+      if [[ ${mini_running} == 1 ]]; then
+        eval $(minishift oc-env)
+        err=$(check_oc_version)
+        check_error $err
+        return
+      fi
+    fi
+    if [[ -d $HOME/.minishift ]]; then
+      oc_bin=$(find $HOME/.minishift/ -name oc -type f | sort | tail -1)
+      if [ -n "$oc_bin" ]; then
+        oc_dir=$(dirname $oc_bin)
+        export PATH=$PATH:$oc_dir
+        return
+      fi
     fi
 
     set -e


### PR DESCRIPTION
If there is no `oc` on PATH, but there is minishift, it uses `minishift oc-env` to get the bundled oc or find the `oc` binary on `$HOME/.minishift`.