### PR TITLE
[ENTESB-14342]: Remove Camel-K 0.3.4 runtime from Syndesis

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -95,10 +95,6 @@ popd > /dev/null
 SYNDESIS_CLI=$(get_syndesis_bin)
 check_error $SYNDESIS_CLI
 
-# Download binary files
-KAMEL_CLI=$(get_kamel_bin)
-check_error $KAMEL_CLI
-
 display_usage() {
   cat <<EOT
 Fuse Online Installation Tool for OCP

--- a/libs/download_functions.sh
+++ b/libs/download_functions.sh
@@ -8,10 +8,6 @@ get_syndesis_bin() {
   get_cli_bin $SYNDESIS_DOWNLOAD_URL $SYNDESIS_BINARY $SYNDESIS_VERSION
 }
 
-get_kamel_bin() {
-  get_cli_bin $CAMEL_K_DOWNLOAD_URL $CAMEL_K_BINARY $CAMEL_K_VERSION
-}
-
 # Download CLI
 get_cli_bin() {
   local url=${1}

--- a/update_ocp.sh
+++ b/update_ocp.sh
@@ -93,10 +93,6 @@ popd > /dev/null
 SYNDESIS_CLI=$(get_syndesis_bin)
 check_error $SYNDESIS_CLI
 
-# Download binary files
-KAMEL_CLI=$(get_kamel_bin)
-check_error $KAMEL_CLI
-
 display_usage() {
   cat <<EOT
 Fuse Online Update Tool for OCP


### PR DESCRIPTION
Removed remaining Camel-K mentions.
Fix for
```
download_functions.sh: line 12: CAMEL_K_DOWNLOAD_URL: unbound variable
```



