### PR TITLE
[ENTESB-15363] - fix if statement + waiting for SA during the update

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -329,19 +329,19 @@ check_error $jaeger_enabled
 if [ "$jaeger_enabled" == "true" ]; then
     # on OCP 4 the jaeger-operator is installed from operatorhub on openshift-operator namespace
     # in that case there is no need to set secrets for it
-    if [ $(is_ocp3) ]; then
+    if [ $(is_ocp3) == "true" ]; then
         wait_for sa jaeger-operator
         result=$(oc secrets link jaeger-operator syndesis-pull-secret --for=pull)
         check_error $result
         # workaround as the previous "oc secrets link" doesn't trigger a pod restart
         oc delete `oc get -o name pod -l name=jaeger-operator`
-    fi
 
-    wait_for sa syndesis-jaeger-ui-proxy
-    result=$(oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull)
-    check_error $result
-    # workaround as the previous "oc secrets link" doesn't trigger a pod restart
-    oc delete `oc get -o name pod -l app.kubernetes.io/name=syndesis-jaeger`
+        wait_for sa syndesis-jaeger-ui-proxy
+        result=$(oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull)
+        check_error $result
+        # workaround as the previous "oc secrets link" doesn't trigger a pod restart
+        oc delete `oc get -o name pod -l app.kubernetes.io/name=syndesis-jaeger`
+    fi
 fi
 
 if [ $(hasflag --watch -w) ] || [ $(hasflag --open -o) ]; then

--- a/libs/openshift_functions.sh
+++ b/libs/openshift_functions.sh
@@ -98,6 +98,19 @@ wait_for() {
   done
 }
 
+wait_for_resource_is_deleted() {
+  local res_type=$1
+  local resource=$2
+
+  local resource_ready=$(check_resource $res_type $resource)
+  while [ $resource_ready == "true" ]; do
+      resource_ready=$(check_resource $res_type $resource)
+      if [ $resource_ready == "true" ]; then
+        sleep 4
+      fi
+  done
+}
+
 # Check if a resource exist in OCP
 check_resource() {
   local kind=$1

--- a/update_ocp.sh
+++ b/update_ocp.sh
@@ -169,19 +169,25 @@ check_error $jaeger_enabled
 if [ "$jaeger_enabled" == "true" ]; then
     # on OCP 4 the jaeger-operator is installed from operatorhub on openshift-operator namespace
     # in that case there is no need to set secrets for it
-    if [ $(is_ocp3) ]; then
+    if [ $(is_ocp3) == "true" ]; then
+        # we need to wait till the update process is started and the previous jaeger-operator SA is deleted ENTESB-15363
+        echo "Waiting till jaeger-operator service account will be deleted and created again (ENTESB-15363)"
+        wait_for_resource_is_deleted sa jaeger-operator
+        
         wait_for sa jaeger-operator
         result=$(oc secrets link jaeger-operator syndesis-pull-secret --for=pull)
         check_error $result
         # workaround as the previous "oc secrets link" doesn't trigger a pod restart
         oc delete `oc get -o name pod -l name=jaeger-operator`
+       
+        wait_for sa syndesis-jaeger-ui-proxy
+        result=$(oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull)
+        check_error $result
+        # workaround as the previous "oc secrets link" doesn't trigger a pod restart
+        oc delete `oc get -o name pod -l app.kubernetes.io/name=syndesis-jaeger`
     fi
 
-    wait_for sa syndesis-jaeger-ui-proxy
-    result=$(oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull)
-    check_error $result
-    # workaround as the previous "oc secrets link" doesn't trigger a pod restart
-    oc delete `oc get -o name pod -l app.kubernetes.io/name=syndesis-jaeger`
+
 fi
 
 cat <<EOT


### PR DESCRIPTION
@claudio4j 
@phantomjinx 
Can you please review this PR ?

I have moved linking syndesis-jaeger-ui-proxy SA with syndesis-pull-secret to the OCP 3.11 if statement because I am assuming that that is not relevant to OCP 4 installation either, is that right?
Also, I added wait_for_resource_is_deleted function due to ENTESB-15363 because we need to be sure that the second jaeger-operator SA will be linked with syndesis-pull-secret in the update script. (the update script didn't wait for starting update process)

