### PR TITLE
Add workaround for ENTESB-17075 also for install script and only for OCP3

### DIFF
--- a/install_ocp.sh
+++ b/install_ocp.sh
@@ -299,9 +299,11 @@ $SYNDESIS_CLI install operator
 set +e
 oc scale deployment syndesis-operator --replicas 0
 result=$(oc secrets link syndesis-operator syndesis-pull-secret --for=pull >$ERROR_FILE 2>&1)
-oc scale deployment syndesis-operator --replicas 1
-
 check_error $result
+if [ $(is_ocp3) == "true" ]; then
+   oc set env deployment/syndesis-operator RELATED_IMAGE_PROMETHEUS='registry.redhat.io/openshift3/prometheus:v3.9'
+fi
+oc scale deployment syndesis-operator --replicas 1
 set -e
 
 # Wait for deployment

--- a/update_ocp.sh
+++ b/update_ocp.sh
@@ -166,7 +166,9 @@ $SYNDESIS_CLI install operator
 oc scale deployment syndesis-operator --replicas 0
 result=$(oc secrets link syndesis-operator syndesis-pull-secret --for=pull >$ERROR_FILE 2>&1)
 check_error $result
-oc set env deployment/syndesis-operator RELATED_IMAGE_PROMETHEUS='registry.redhat.io/openshift3/prometheus:v3.9'
+if [ $(is_ocp3) == "true" ]; then
+   oc set env deployment/syndesis-operator RELATED_IMAGE_PROMETHEUS='registry.redhat.io/openshift3/prometheus:v3.9'
+fi
 oc scale deployment syndesis-operator --replicas 1
 
 jaeger_enabled=$(oc get syndesis app -o jsonpath='{.spec.addons.jaeger.enabled}')


### PR DESCRIPTION
Added workaround for ENTESB-17075 to the install script as well for the customer who wants to install fresh Fuse Online 7.9 on OCP 3.11. Even though, the prometheus:v4.7 image works with a fresh installation, the next update to 7.10 can be a problem (because the update script uses v3.9 Prometheus image as a workaround of that issue). 

If we allow that, the user which installs FO7.9 will be using Prometheus v4.7 but the user who upgrades from FO7.8 will be using Prometheus v3.9. That can cause a problem with the upgrade to FO10.